### PR TITLE
Fix error introduced by https://github.com/ziglang/zig/pull/18994

### DIFF
--- a/src/zon_get_fields.zig
+++ b/src/zon_get_fields.zig
@@ -709,7 +709,7 @@ fn MakeReportStructType(tgt_type: type) type
     return @Type(.{
                     .Struct =
                     .{
-                        .layout = .Auto,
+                        .layout = .auto,
                         .backing_integer = null,
                         .fields = &flds,
                         .decls = &.{},


### PR DESCRIPTION
In recent [Zig versions](https://github.com/ziglang/zig/pull/18994), many enum fields were changed to lowercase (.some_thing instead of .SomeThing). This introduced an error here which is fixed by this pull request.